### PR TITLE
fix getFlagValues in Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -87,7 +87,11 @@ parseLibraries = concatMap go
                           Nothing     -> []
 
 getFlagValues f s = map (\(_:_:v) -> v) filtered
-  where filtered = filter (\(_:f':_) -> f==f') (words . init $ s)
+  where filtered = filter (\(_:f':_) -> f==f') (words . rstrip $ s)
+        rstrip = reverse . rlstrip . reverse
+        rlstrip ('\n':'\r':x) = x
+        rlstrip ('\n':x) = x
+        rlstrip x = x
  
 staticLibNameAndPath :: FilePath -> Maybe (String, FilePath)
 staticLibNameAndPath p


### PR DESCRIPTION
`getFlagValues` is used twice in Setup.hs.

The first time it turns `"-I/usr/include/gdal"` into `["/usr/include/gda"]`
the second time it turns `"-L/usr/lib -lgdal"` into `["/usr/lib"]`

Removing the `init` fixes the behavior for the include. I'm not sure why this `init` was there, was it stripping newlines or something?